### PR TITLE
Fix crash in OnDismiss

### DIFF
--- a/src/com/android/packageinstaller/UninstallerActivity.java
+++ b/src/com/android/packageinstaller/UninstallerActivity.java
@@ -109,7 +109,9 @@ public class UninstallerActivity extends Activity {
         @Override
         public void onDismiss(DialogInterface dialog) {
             super.onDismiss(dialog);
-            getActivity().finish();
+            if (isAdded()) {
+                getActivity().finish();
+            }
         }
     }
 
@@ -127,9 +129,11 @@ public class UninstallerActivity extends Activity {
         @Override
         public void onDismiss(DialogInterface dialog) {
             super.onDismiss(dialog);
-            ((UninstallerActivity) getActivity()).dispatchAborted();
-            getActivity().setResult(Activity.RESULT_FIRST_USER);
-            getActivity().finish();
+            if (isAdded()) {
+                ((UninstallerActivity) getActivity()).dispatchAborted();
+                getActivity().setResult(Activity.RESULT_FIRST_USER);
+                getActivity().finish();
+            }
         }
     }
 


### PR DESCRIPTION
Steps to reproduce the crash are as follows:
1. Launch Settings >> Apps
2. Select an app to uninstall
3. Select “uninstall” then confirmation comes up
4. Tap Home key and launch Settings apps again
5. You see app crash notification

This was due to DialogFragment.onDismiss() called after the
underlying activity was stopped and detached.
In other cases (cancel, delete, back key) there is no problem.
For home key scenario it is enough to check, if dialog is
currently added to its activity. Fragment.isAdded() checks
internally, if its activity is not null and if it's added to this
activity.

BUG: https://code.google.com/p/android/issues/detail?id=144163

Change-Id: I3cb75ec392fd68f131ec65e4eafae2351e95ea25
Signed-off-by: Vibhor Chaudhary cvibhu0009@gmail.com
